### PR TITLE
Bug Update

### DIFF
--- a/src/RevivalPMMP/TimeStopper/command/TimeCommand.php
+++ b/src/RevivalPMMP/TimeStopper/command/TimeCommand.php
@@ -32,7 +32,7 @@ class TimeCommand extends Command{
 		$plugin = TimeStopper::getInstance();
 
 
-		switch(strtolower($args[0])){
+		switch($args[0]){
 			case "add":
 				if($sender->hasPermission("pocketmine.command.time.add")){
 					if(!isset($args[1]) or !is_numeric($args[1])){


### PR DESCRIPTION
This PR simply removes the `strtolower` function in the switch statement for command arguments to make the sub-commands case-insensitive.